### PR TITLE
yard doc fix - unnecessary yard parameter

### DIFF
--- a/lib/dry/events/bus.rb
+++ b/lib/dry/events/bus.rb
@@ -18,7 +18,6 @@ module Dry
 
       # Initialize a new event bus
       #
-      # @param [Symbol] id The bus identifier
       # @param [Hash] events A hash with events
       # @param [Hash] listeners A hash with listeners
       #


### PR DESCRIPTION
It seems that down the road, this first argument was abandoned but the yardoc remained as reported by https://app.coditsu.io/dry-rb/builds/validations/a98578d3-265e-4bf0-8f5a-317639e81ea4/offenses?q[offense_name_cont]=UnknownParameterName