### PR TITLE
[skip ci] Fix RDoc parsing for Dry::Events::Listener

### DIFF
--- a/lib/dry/events/listener.rb
+++ b/lib/dry/events/listener.rb
@@ -11,7 +11,7 @@ module Dry
     #
     #     register_event("users.created")
     #   end
-
+    #
     #   class MyListener
     #     include Dry::Events::Listener[:app]
     #


### PR DESCRIPTION
While reading the API documentation for [Dry::Events::Listener](http://www.rubydoc.info/gems/dry-events/Dry/Events/Listener) I checked something weird on the Overview section, after some review it appears to be a problem related to rDoc parsing the comments.

If accepted, the documentation for `Dry::Events::Listener` would change from this:

![events_listener_before](https://user-images.githubusercontent.com/1037088/37649038-e73a0a4e-2bed-11e8-82c7-b129fb4cb354.png)

To this:

![events_listener_after](https://user-images.githubusercontent.com/1037088/37649345-b5b11692-2bee-11e8-83bb-5835f6258ec4.png)


Manually tested using these rDoc versions:
- 5.0.0
- 6.0.1