### PR TITLE
Enhanced queries/filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+# to-be-released
+
+## Added
+
+- Subscription filters can be more complex: nested hash inclusion, array inclusion, and proc checks were added (flash-gordon)
+  ```ruby
+  # nested hash check
+  subscribe(:event, logger: { level: :info })
+  # pass
+  trigger(:event, logger: { level: :info, output: :stdin })
+  # filtered out
+  trigger(:event, logger: { level: :debug })
+  trigger(:event, something: :else)
+
+  # array inclusion
+  subscribe(:event, logger: { level: %i(info warn error) })
+  # pass
+  trigger(:event, logger: { level: :info })
+  trigger(:event, logger: { level: :error })
+  trigger(:event, logger: { level: :info, output: :stdin })
+  # filtered out
+  trigger(:event, logger: { level: :debug })
+
+  # proc checks
+  # here acts as array inclusion example
+  subscribe(:event, logger: { level: -> level { %i(info warn error).include?(level) })
+  ```
+
 # v0.1.0 2018-01-02
 
 First public release

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ group :test do
 end
 
 group :tools do
-  gem 'byebug', platform: :mri
+  gem 'pry'
+  gem 'pry-byebug', platform: :mri
 end

--- a/lib/dry/events/bus.rb
+++ b/lib/dry/events/bus.rb
@@ -29,10 +29,10 @@ module Dry
 
       # @api private
       def process(event_id, payload)
-        listeners[event_id].each do |(listener, query)|
+        listeners[event_id].each do |listener, filter|
           event = events[event_id].payload(payload)
 
-          if event.trigger?(query)
+          if filter.(payload)
             yield(event, listener)
           end
         end
@@ -46,12 +46,12 @@ module Dry
       end
 
       # @api private
-      def attach(listener, query)
+      def attach(listener, filter)
         events.each do |id, event|
           meth = event.listener_method
 
           if listener.respond_to?(meth)
-            listeners[id] << [listener.method(meth), query]
+            listeners[id] << [listener.method(meth), filter]
           end
         end
       end
@@ -67,14 +67,14 @@ module Dry
       end
 
       # @api private
-      def subscribe(event_id, query, &block)
-        listeners[event_id] << [block, query]
+      def subscribe(event_id, filter, &block)
+        listeners[event_id] << [block, filter]
         self
       end
 
       # @api private
       def subscribed?(listener)
-        listeners.values.any? { |value| value.any? { |(block, _)| block.equal?(listener) } }
+        listeners.values.any? { |value| value.any? { |block, _| block.equal?(listener) } }
       end
     end
   end

--- a/lib/dry/events/event.rb
+++ b/lib/dry/events/event.rb
@@ -67,11 +67,6 @@ module Dry
       end
 
       # @api private
-      def trigger?(query)
-        query.empty? || query.all? { |key, value| payload[key] == value }
-      end
-
-      # @api private
       def listener_method
         @listener_method ||= :"on_#{id.to_s.gsub(DOT, UNDERSCORE)}"
       end

--- a/lib/dry/events/filter.rb
+++ b/lib/dry/events/filter.rb
@@ -2,19 +2,40 @@ require 'set'
 
 module Dry
   module Events
+    # Event filter
+    #
+    # A filter cherry-picks probes payload of events.
+    # Events not matching the predicates don't fire callbacks.
+    #
+    # @api private
     class Filter
       NO_MATCH = Object.new.freeze
 
+      # @!attribute [r] events
+      #   @return [Array] A list of lambdas checking payloads
       attr_reader :checks
 
+      # Create a new filter
+      #
+      # @param [Hash] filter Source filter
+      #
+      # @api private
       def initialize(filter)
         @checks = build_checks(filter)
       end
 
+      # Test event payload against the checks
+      #
+      # @param [Hash] payload Event payload
+      #
+      # @api private
       def call(payload = EMPTY_HASH)
         checks.all? { |check| check.(payload) }
       end
 
+      # Recursively build checks
+      #
+      # @api private
       def build_checks(filter, checks = EMPTY_ARRAY, keys = EMPTY_ARRAY)
         if filter.is_a?(Hash)
           filter.reduce(checks) do |cs, (key, value)|
@@ -25,6 +46,7 @@ module Dry
         end
       end
 
+      # @api private
       def compare(path, predicate, payload)
         value = path.reduce(payload) do |acc, key|
           if acc.is_a?(Hash) && acc.key?(key)
@@ -37,6 +59,7 @@ module Dry
         predicate.(value)
       end
 
+      # @api private
       def predicate(value)
         case value
         when Proc then value

--- a/lib/dry/events/filter.rb
+++ b/lib/dry/events/filter.rb
@@ -1,0 +1,39 @@
+module Dry
+  module Events
+    class Filter
+      NO_MATCH = Object.new.freeze
+
+      attr_reader :checks
+
+      def initialize(filter)
+        @checks = build_checks(filter)
+      end
+
+      def call(payload)
+        checks.all? { |check| check.(payload) }
+      end
+
+      def build_checks(hash, keys = [])
+        hash.each_with_object([]) do |(key, value), checks|
+          path = [*keys, key]
+
+          if value.is_a?(Hash)
+            checks.concat(build_checks(value, path))
+          else
+            checks << method(:compare).curry.(path, value)
+          end
+        end
+      end
+
+      def compare(path, value, payload)
+        value == path.reduce(payload) do |acc, key|
+          if acc.is_a?(Hash)
+            acc.fetch(key, NO_MATCH)
+          else
+            NO_MATCH
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/events/filter.rb
+++ b/lib/dry/events/filter.rb
@@ -11,20 +11,17 @@ module Dry
         @checks = build_checks(filter)
       end
 
-      def call(payload)
+      def call(payload = EMPTY_HASH)
         checks.all? { |check| check.(payload) }
       end
 
-      def build_checks(hash, keys = [])
-        hash.each_with_object([]) do |(key, value), checks|
-          path = [*keys, key]
-
-          if value.is_a?(Hash)
-            checks.concat(build_checks(value, path))
-          else
-            predicate = predicate(value)
-            checks << method(:compare).curry.(path, predicate)
+      def build_checks(filter, checks = EMPTY_ARRAY, keys = EMPTY_ARRAY)
+        if filter.is_a?(Hash)
+          filter.reduce(checks) do |cs, (key, value)|
+            build_checks(value, cs, [*keys, key])
           end
+        else
+          [*checks, method(:compare).curry.(keys, predicate(filter))]
         end
       end
 

--- a/lib/dry/events/publisher.rb
+++ b/lib/dry/events/publisher.rb
@@ -5,6 +5,7 @@ require 'dry/core/class_attributes'
 require 'dry/events/constants'
 require 'dry/events/event'
 require 'dry/events/bus'
+require 'dry/events/filter'
 
 module Dry
   module Events
@@ -116,13 +117,13 @@ module Dry
         # Subscribe to an event
         #
         # @param [Symbol,String] event_id The event identifier
-        # @param [Hash] query An optional query for conditional listeners
+        # @param [Hash] filter_hash An optional filter for conditional listeners
         #
         # @return [Class] publisher class
         #
         # @api public
-        def subscribe(event_id, query = EMPTY_HASH, &block)
-          listeners[event_id] << [block, query]
+        def subscribe(event_id, filter_hash = EMPTY_HASH, &block)
+          listeners[event_id] << [block, Filter.new(filter_hash)]
           self
         end
 
@@ -180,19 +181,21 @@ module Dry
 
         # Subscribe to events.
         #
-        # If the query parameter is provided, filters events by payload.
+        # If the filter parameter is provided, filters events by payload.
         #
         # @param [Symbol,String,Object] object_or_event_id The event identifier or a listener object
-        # @param [Hash] query An optional event filter
+        # @param [Hash] filter_hash An optional event filter
         #
         # @return [Object] self
         #
         # @api public
-        def subscribe(object_or_event_id, query = EMPTY_HASH, &block)
+        def subscribe(object_or_event_id, filter_hash = EMPTY_HASH, &block)
+          filter = Filter.new(filter_hash)
+
           if block
-            __bus__.subscribe(object_or_event_id, query, &block)
+            __bus__.subscribe(object_or_event_id, filter, &block)
           else
-            __bus__.attach(object_or_event_id, query)
+            __bus__.attach(object_or_event_id, filter)
           end
           self
         end
@@ -217,7 +220,7 @@ module Dry
 
         # Utility method which yields event with each of its listeners
         #
-        # Listeners are already filtered out when query was provided during
+        # Listeners are already filtered out when filter was provided during
         # subscription
         #
         # @param [Symbol,String] event_id The event identifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,8 @@ if RUBY_ENGINE == 'ruby' && ENV['COVERAGE'] == 'true'
 end
 
 begin
-  require 'byebug'
+  require 'pry'
+  require 'pry-byebug'
 rescue LoadError; end
 
 require 'dry-events'
@@ -17,7 +18,9 @@ Dir[SPEC_ROOT.join('shared/**/*.rb')].each(&method(:require))
 Dir[SPEC_ROOT.join('support/**/*.rb')].each(&method(:require))
 
 RSpec.configure do |config|
+  config.warnings = true
   config.disable_monkey_patching!
+  config.filter_run_when_matching :focus
 
   config.after(:example) do
     Dry::Events::Publisher.instance_variable_set(:@__registry__, Concurrent::Map.new)

--- a/spec/unit/dry/events/filter_spec.rb
+++ b/spec/unit/dry/events/filter_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe Dry::Events::Filter do
+  subject(:filter) { described_class.new(query) }
+
+  context 'nested hash' do
+    let(:query) do
+      { logger: { level: :info } }
+    end
+
+    specify do
+      expect(filter.()).to be false
+      expect(filter.(logger: { level: :info, output: :stdin })).to be true
+      expect(filter.(logger: { level: :debug })).to be false
+      expect(filter.(logger: :debug)).to be false
+    end
+  end
+
+  context 'multi-value check' do
+    let(:query) do
+      { logger: { level: :info, output: :stdin } }
+    end
+
+    specify do
+      expect(filter.()).to be false
+      expect(filter.(logger: { level: :info, output: :stdin })).to be true
+      expect(filter.(logger: { level: :info })).to be false
+    end
+  end
+
+  context 'top-level array' do
+    let(:query) { %i(error fatal) }
+
+    specify do
+      expect(filter.()).to be false
+      expect(filter.(random: :hash)).to be false
+      expect(filter.(:error)).to be true
+    end
+  end
+
+  context 'nested array' do
+    let(:query) do
+      { logger: { level: %i(info warn error fatal) } }
+    end
+
+    specify do
+      expect(filter.()).to be false
+      expect(filter.(logger: { level: :info, output: :stdin })).to be true
+      expect(filter.(logger: { level: :fatal })).to be true
+      expect(filter.(logger: { level: :debug })).to be false
+      expect(filter.(level: :debug)).to be false
+    end
+  end
+
+  context 'nested proc' do
+    let(:query) do
+      { logger: { level: -> level { %i(error fatal).include?(level) } } }
+    end
+
+    specify do
+      expect(filter.()).to be false
+      expect(filter.(logger: { level: :error, output: :stdin })).to be true
+    end
+  end
+
+  context 'top-level proc' do
+    let(:query) do
+      -> level: :debug, ** { %i(error fatal).include?(level) }
+    end
+
+    specify do
+      expect(filter.()).to be false
+      expect(filter.(level: :error, output: :stdin)).to be true
+    end
+  end
+end

--- a/spec/unit/dry/events/listener_spec.rb
+++ b/spec/unit/dry/events/listener_spec.rb
@@ -56,6 +56,25 @@ RSpec.describe Dry::Events::Listener do
 
         expect(captured).to eql([logger: { level: :info, output: :stdin }])
       end
+
+      it 'filters events by inclusion' do
+        listener = self.listener
+
+        listener.subscribe(:test_event, logger: { level: %i(info warn error fatal) }) do |event|
+          captured << event.payload
+        end
+
+        publisher.publish(:test_event)
+        publisher.publish(:test_event, logger: { level: :info, output: :stdin })
+        publisher.publish(:test_event, logger: { level: :fatal })
+        publisher.publish(:test_event, logger: { level: :debug })
+        publisher.publish(:test_event, logger: :debug)
+
+        expect(captured).to eql([
+          { logger: { level: :info, output: :stdin } },
+          { logger: { level: :fatal } }
+        ])
+      end
     end
   end
 end

--- a/spec/unit/dry/events/listener_spec.rb
+++ b/spec/unit/dry/events/listener_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Dry::Events::Listener do
     }.new
   end
 
-
   describe '.subscribe' do
     let(:captured) { [] }
 
@@ -40,60 +39,6 @@ RSpec.describe Dry::Events::Listener do
         publisher.publish(:test_event, level: :info)
 
         expect(captured).to eql([level: :info])
-      end
-
-      it 'filters events using nested query' do
-        listener = self.listener
-
-        listener.subscribe(:test_event, logger: { level: :info }) do |event|
-          captured << event.payload
-        end
-
-        publisher.publish(:test_event)
-        publisher.publish(:test_event, logger: { level: :info, output: :stdin })
-        publisher.publish(:test_event, logger: { level: :debug })
-        publisher.publish(:test_event, logger: :debug)
-
-        expect(captured).to eql([logger: { level: :info, output: :stdin }])
-      end
-
-      it 'filters events by inclusion' do
-        listener = self.listener
-
-        listener.subscribe(:test_event, logger: { level: %i(info warn error fatal) }) do |event|
-          captured << event.payload
-        end
-
-        publisher.publish(:test_event)
-        publisher.publish(:test_event, logger: { level: :info, output: :stdin })
-        publisher.publish(:test_event, logger: { level: :fatal })
-        publisher.publish(:test_event, logger: { level: :debug })
-        publisher.publish(:test_event, logger: :debug)
-
-        expect(captured).to eql([
-          { logger: { level: :info, output: :stdin } },
-          { logger: { level: :fatal } }
-        ])
-      end
-
-      it 'filters by proc' do
-        listener = self.listener
-        predicate = -> level { %i(info warn error fatal).include?(level) }
-
-        listener.subscribe(:test_event, logger: { level: predicate }) do |event|
-          captured << event.payload
-        end
-
-        publisher.publish(:test_event)
-        publisher.publish(:test_event, logger: { level: :info, output: :stdin })
-        publisher.publish(:test_event, logger: { level: :fatal })
-        publisher.publish(:test_event, logger: { level: :debug })
-        publisher.publish(:test_event, logger: :debug)
-
-        expect(captured).to eql([
-          { logger: { level: :info, output: :stdin } },
-          { logger: { level: :fatal } }
-        ])
       end
     end
   end

--- a/spec/unit/dry/events/listener_spec.rb
+++ b/spec/unit/dry/events/listener_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe Dry::Events::Listener do
           { logger: { level: :fatal } }
         ])
       end
+
+      it 'filters by proc' do
+        listener = self.listener
+        predicate = -> level { %i(info warn error fatal).include?(level) }
+
+        listener.subscribe(:test_event, logger: { level: predicate }) do |event|
+          captured << event.payload
+        end
+
+        publisher.publish(:test_event)
+        publisher.publish(:test_event, logger: { level: :info, output: :stdin })
+        publisher.publish(:test_event, logger: { level: :fatal })
+        publisher.publish(:test_event, logger: { level: :debug })
+        publisher.publish(:test_event, logger: :debug)
+
+        expect(captured).to eql([
+          { logger: { level: :info, output: :stdin } },
+          { logger: { level: :fatal } }
+        ])
+      end
     end
   end
 end

--- a/spec/unit/dry/events/listener_spec.rb
+++ b/spec/unit/dry/events/listener_spec.rb
@@ -15,17 +15,47 @@ RSpec.describe Dry::Events::Listener do
     }.new
   end
 
-  describe '.subscribe' do
-    it 'subscribes a listener at class level' do
-      result = []
 
+  describe '.subscribe' do
+    let(:captured) { [] }
+
+    it 'subscribes a listener at class level' do
       listener.subscribe(:test_event) do |event|
-        result << event.id
+        captured << event.id
       end
 
       publisher.publish(:test_event)
 
-      expect(result).to eql([:test_event])
+      expect(captured).to eql([:test_event])
+    end
+
+    describe 'filters' do
+      it 'filters events' do
+        listener.subscribe(:test_event, level: :info) do |event|
+          captured << event.payload
+        end
+
+        publisher.publish(:test_event)
+        publisher.publish(:test_event, level: :debug)
+        publisher.publish(:test_event, level: :info)
+
+        expect(captured).to eql([level: :info])
+      end
+
+      it 'filters events using nested query' do
+        listener = self.listener
+
+        listener.subscribe(:test_event, logger: { level: :info }) do |event|
+          captured << event.payload
+        end
+
+        publisher.publish(:test_event)
+        publisher.publish(:test_event, logger: { level: :info, output: :stdin })
+        publisher.publish(:test_event, logger: { level: :debug })
+        publisher.publish(:test_event, logger: :debug)
+
+        expect(captured).to eql([logger: { level: :info, output: :stdin }])
+      end
     end
   end
 end


### PR DESCRIPTION
@solnic I'm not sure why I asked you about filters since they were already there. Anyway, I decided to improve them. Are you OK with renaming queries to filters? It's internal so affects nothing, it just looks better: `if filter.(payload)` vs `if query.(payload)`.

In my current plan to support `subscribe(:foo, log_level: %i(info warn error))` that is array filters