### PR TITLE
CI: Use 2.4.6, 2.6.3, jruby-9.2.7.0, drop 2.3.8 (EOL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install: gem update --system
 after_success:
   - '[ "${TRAVIS_JOB_NUMBER#*.}" = "1" ] && [ "$TRAVIS_BRANCH" = "master" ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.6.2
+  - 2.6.3
   - 2.5.5
   - 2.4.6
   - jruby-9.2.7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.6.2
   - 2.5.5
   - 2.4.6
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
   - truffleruby
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ after_success:
 rvm:
   - 2.6.2
   - 2.5.5
-  - 2.4.5
-  - 2.3.8
+  - 2.4.6
   - jruby-9.2.6.0
   - truffleruby
 matrix:


### PR DESCRIPTION
This PR updates CI matrix to use 2.4.6, and drops 2.3, which is EOL.