### PR TITLE
Raise error when publishing an unregistered event

### DIFF
--- a/lib/dry/events/publisher.rb
+++ b/lib/dry/events/publisher.rb
@@ -38,9 +38,9 @@ module Dry
       def initialize(object_or_event_id)
         case object_or_event_id
         when String, Symbol
-          super("You are trying to publish an event: `#{object_or_event_id}` that has not been registered")
+          super("You are trying to publish an unregistered event: `#{object_or_event_id}`")
         else
-          super('You are trying to publish an event that has not been registered')
+          super("You are trying to publish an unregistered event")
         end
       end
     end

--- a/lib/dry/events/publisher.rb
+++ b/lib/dry/events/publisher.rb
@@ -34,6 +34,17 @@ module Dry
       end
     end
 
+    UnregisteredEventError = Class.new(StandardError) do
+      def initialize(object_or_event_id)
+        case object_or_event_id
+        when String, Symbol
+          super("You are trying to publish an event: `#{object_or_event_id}` that has not been registered")
+        else
+          super('You are trying to publish an event that has not been registered')
+        end
+      end
+    end
+
     # Extension used for classes that can publish events
     #
     # @example
@@ -191,8 +202,12 @@ module Dry
         #
         # @api public
         def publish(event_id, payload = EMPTY_HASH)
-          __bus__.publish(event_id, payload)
-          self
+          if __bus__.can_handle?(event_id)
+            __bus__.publish(event_id, payload)
+            self
+          else
+            raise UnregisteredEventError, event_id
+          end
         end
         alias_method :trigger, :publish
 

--- a/spec/unit/dry/events/publisher_spec.rb
+++ b/spec/unit/dry/events/publisher_spec.rb
@@ -130,6 +130,12 @@ RSpec.describe Dry::Events::Publisher do
 
       expect(result).to eql([true])
     end
+
+    it 'raises an exception when publishing an unregistered event' do
+      expect {
+        publisher.publish(:unregistered_event, {})
+      }.to raise_error(Dry::Events::UnregisteredEventError, /unregistered_event/)
+    end
   end
 
   describe '#process' do

--- a/spec/unit/dry/events/publisher_spec.rb
+++ b/spec/unit/dry/events/publisher_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Dry::Events::Publisher do
       expect(result).to eql([true])
     end
 
-    it 'raises an exception when publishing an unregistered event' do
+    it "raises an exception when publishing an unregistered event" do
       expect {
         publisher.publish(:unregistered_event, {})
       }.to raise_error(Dry::Events::UnregisteredEventError, /unregistered_event/)


### PR DESCRIPTION
This builds on the work done in #4. When attempting to publish an unknown event, an exception will now occur.

Closes #13 