### PR TITLE
Allow Publisher#subscribed? to check instance method listeners.

### DIFF
--- a/lib/dry/events/bus.rb
+++ b/lib/dry/events/bus.rb
@@ -77,9 +77,11 @@ module Dry
       # @api private
       def subscribed?(listener)
         listeners.values.any? do |value|
-          case listener
-          when Proc   then value.any? { |block, _| block.equal?(listener) }
-          when Method then value.any? { |block, _| listener.owner == block.owner && listener.name == block.name }
+          value.any? do |block, _|
+            case listener
+            when Proc   then block.equal?(listener)
+            when Method then listener.owner == block.owner && listener.name == block.name
+            end
           end
         end
       end

--- a/lib/dry/events/bus.rb
+++ b/lib/dry/events/bus.rb
@@ -76,7 +76,12 @@ module Dry
 
       # @api private
       def subscribed?(listener)
-        listeners.values.any? { |value| value.any? { |block, _| block.equal?(listener) } }
+        listeners.values.any? do |value|
+          case listener
+          when Proc   then value.any? { |block, _| block.equal?(listener) }
+          when Method then value.any? { |block, _| listener.owner == block.owner && listener.name == block.name }
+          end
+        end
       end
 
       # @api private

--- a/lib/dry/events/bus.rb
+++ b/lib/dry/events/bus.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/events/constants'
+require "dry/events/constants"
 
 module Dry
   module Events

--- a/spec/unit/dry/events/publisher_spec.rb
+++ b/spec/unit/dry/events/publisher_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/events/publisher'
+require "dry/events/publisher"
 
 RSpec.describe Dry::Events::Publisher do
   subject(:publisher) do
@@ -11,8 +11,8 @@ RSpec.describe Dry::Events::Publisher do
     }.new
   end
 
-  describe '.[]' do
-    it 'creates a publisher extension with provided id' do
+  describe ".[]" do
+    it "creates a publisher extension with provided id" do
       publisher = Class.new do
         include Dry::Events::Publisher[:my_publisher]
       end
@@ -20,7 +20,7 @@ RSpec.describe Dry::Events::Publisher do
       expect(Dry::Events::Publisher.registry[:my_publisher]).to be(publisher)
     end
 
-    it 'does not allow same id to be used for than once' do
+    it "does not allow same id to be used for than once" do
       create_publisher = -> do
         Class.new do
           include Dry::Events::Publisher[:my_publisher]
@@ -33,8 +33,8 @@ RSpec.describe Dry::Events::Publisher do
     end
   end
 
-  describe '.subscribe' do
-    it 'subscribes a listener at class level' do
+  describe ".subscribe" do
+    it "subscribes a listener at class level" do
       listener = -> * {}
 
       publisher.class.subscribe(:test_event, &listener)
@@ -42,7 +42,7 @@ RSpec.describe Dry::Events::Publisher do
       expect(publisher.subscribed?(listener)).to be(true)
     end
 
-    it 'raises an exception when subscribing to an unregister event' do
+    it "raises an exception when subscribing to an unregister event" do
       listener = -> * {}
 
       expect {
@@ -51,8 +51,8 @@ RSpec.describe Dry::Events::Publisher do
     end
   end
 
-  describe '#register_event' do
-    it 'registers a new event at instance level' do
+  describe "#register_event" do
+    it "registers a new event at instance level" do
       listener = -> * {}
 
       publisher.register_event(:test_another_event).subscribe(:test_another_event, &listener)
@@ -61,8 +61,8 @@ RSpec.describe Dry::Events::Publisher do
     end
   end
 
-  describe '#subscribe' do
-    it 'subscribes a listener function' do
+  describe "#subscribe" do
+    it "subscribes a listener function" do
       listener = -> * {}
 
       publisher.subscribe(:test_event, &listener)
@@ -70,7 +70,7 @@ RSpec.describe Dry::Events::Publisher do
       expect(publisher.subscribed?(listener)).to be(true)
     end
 
-    it 'subscribes a listener object' do
+    it "subscribes a listener object" do
       listener = Class.new do
         attr_reader :captured
 
@@ -83,18 +83,18 @@ RSpec.describe Dry::Events::Publisher do
         end
       end.new
 
-      publisher.subscribe(listener).publish(:test_event, message: 'it works')
+      publisher.subscribe(listener).publish(:test_event, message: "it works")
 
-      expect(listener.captured).to eql(['it works'])
+      expect(listener.captured).to eql(["it works"])
 
       publisher.unsubscribe(listener)
 
-      publisher.publish(:test_event, message: 'it works')
+      publisher.publish(:test_event, message: "it works")
 
-      expect(listener.captured).to eql(['it works'])
+      expect(listener.captured).to eql(["it works"])
     end
 
-    it 'raises an exception when subscribing with no methods to execute' do
+    it "raises an exception when subscribing with no methods to execute" do
       listener = Object.new
 
       expect {
@@ -102,24 +102,26 @@ RSpec.describe Dry::Events::Publisher do
       }.to raise_error(Dry::Events::InvalidSubscriberError, /never be executed/)
     end
 
-    it 'does not raise an exception when subscriber has methods for notification' do
+    it "does not raise an exception when subscriber has methods for notification" do
       listener = Object.new
-      def listener.on_test_event; nil; end
+      def listener.on_test_event;
+        nil;
+      end
       expect { publisher.subscribe(listener) }.not_to raise_error
     end
   end
 
-  describe '#publish' do
-    it 'publishes an event' do
+  describe "#publish" do
+    it "publishes an event" do
       result = []
       listener = -> event { result << event[:message] }
 
-      publisher.subscribe(:test_event, &listener).publish(:test_event, message: 'it works')
+      publisher.subscribe(:test_event, &listener).publish(:test_event, message: "it works")
 
-      expect(result).to eql(['it works'])
+      expect(result).to eql(["it works"])
     end
 
-    it 'publishes an event filtered by a query' do
+    it "publishes an event filtered by a query" do
       result = []
       listener = -> e { result << e[:test] }
 
@@ -138,26 +140,31 @@ RSpec.describe Dry::Events::Publisher do
     end
   end
 
-  describe '#process' do
-    it 'yields event and its listeners' do
+  describe "#process" do
+    it "yields event and its listeners" do
       result = []
       listener = -> event { result << event.id }
 
       publisher.subscribe(:test_event, &listener)
 
-      publisher.process(:test_event) do |event, listener|
-        listener.(event)
+      publisher.process(:test_event) do |event, list|
+        list.(event)
       end
 
       expect(result).to eql([:test_event])
     end
   end
 
-  describe '#subscribed?' do
-    it 'returns true when checking for previously subscribed instance methods' do
+  describe "#subscribed?" do
+    it "returns true when checking for previously subscribed instance methods" do
       listener = Object.new
-      def listener.on_test_event; nil; end
-      def listener.on_another_test_event; nil; end
+      def listener.on_test_event
+        nil
+      end
+
+      def listener.on_another_test_event
+        nil
+      end
       subject.register_event(:another_test_event)
       subject.subscribe(listener)
       expect(publisher.subscribed?(listener.method(:on_test_event))).to be(true)

--- a/spec/unit/dry/events/publisher_spec.rb
+++ b/spec/unit/dry/events/publisher_spec.rb
@@ -152,4 +152,16 @@ RSpec.describe Dry::Events::Publisher do
       expect(result).to eql([:test_event])
     end
   end
+
+  describe '#subscribed?' do
+    it 'returns true when checking for previously subscribed instance methods' do
+      listener = Object.new
+      def listener.on_test_event; nil; end
+      def listener.on_another_test_event; nil; end
+      subject.register_event(:another_test_event)
+      subject.subscribe(listener)
+      expect(publisher.subscribed?(listener.method(:on_test_event))).to be(true)
+      expect(publisher.subscribed?(listener.method(:on_another_test_event))).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
## The Issue

As the PR title described, `Publisher#subscribed?` is always returning false for methods.
```ruby
class MyListener
  def on_event(event); end
end

class MyPublisher
  include Dry::Events::Publisher[:my_publisher]
  
  register_event(:event)
end

my_publisher = MyPublisher.new
my_listener = MyListener.new

my_publisher.subscribe(my_listener)

my_publisher.subscribed?(my_listener.method(:on_event))
# => false, but should be true
```

## Changes
- `Publisher#subscribed?(listener)` now returns the correct value if `listener` is a `Method`.
