### PR TITLE
Make listeners hash thread-safe

### DIFF
--- a/lib/dry/events/constants.rb
+++ b/lib/dry/events/constants.rb
@@ -6,6 +6,8 @@ module Dry
   module Events
     include Dry::Core::Constants
 
-    LISTENERS_HASH = Concurrent::Map.new { |h, k| h[k] = [] }
+    LISTENERS_HASH = Concurrent::Map.new do |h, k|
+      h.compute_if_absent(k) { [] }
+    end
   end
 end


### PR DESCRIPTION
Current (before changes) implementation will fail if several threads start to subscribe with the same key. This can lead to weird bugs that are nearly impossible to trace.