### PR TITLE
Make `#unsubscribe` functional when both block-based subscribers and listener objects are used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,3 @@ gem "dry-core", github: "dry-rb/dry-core", branch: "main"
 group :test do
   gem "rack"
 end
-

--- a/lib/dry/events/bus.rb
+++ b/lib/dry/events/bus.rb
@@ -63,6 +63,8 @@ module Dry
         listeners.each do |id, memo|
           memo.each do |tuple|
             current_listener, _ = tuple
+            next unless current_listener.is_a?(Method)
+
             listeners[id].delete(tuple) if current_listener.receiver.equal?(listener)
           end
         end

--- a/spec/unit/dry/events/publisher_spec.rb
+++ b/spec/unit/dry/events/publisher_spec.rb
@@ -111,6 +111,41 @@ RSpec.describe Dry::Events::Publisher do
     end
   end
 
+  describe "#unsubscribe" do
+    it "unsubscribes a listener" do
+      listener = Class.new do
+        attr_reader :captured
+
+        def initialize
+          @captured = []
+        end
+
+        def on_test_event(event)
+          captured << event[:message]
+        end
+      end.new
+
+      captured_by_block = []
+
+      publisher.subscribe(:test_event) do |event|
+        captured_by_block << event[:message]
+      end
+      publisher.subscribe(listener)
+
+      publisher.publish(:test_event, message: "it works")
+
+      expect(listener.captured).to eql(["it works"])
+      expect(captured_by_block).to eql(["it works"])
+
+      publisher.unsubscribe(listener)
+
+      publisher.publish(:test_event, message: "it works")
+
+      expect(listener.captured).to eql(["it works"])
+      expect(captured_by_block).to eql(["it works", "it works"])
+    end
+  end
+
   describe "#publish" do
     it "publishes an event" do
       result = []


### PR DESCRIPTION
Reproduction script:

```ruby
#!/usr/bin/env ruby

require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'dry-events', require: 'dry/events', path: '.'
end

class Monitor
  include Dry::Events::Publisher["Monitor"]
end

monitor = Monitor.new

AGGREGATOR = []

class Listener
  def on_test(event)
    p "listener: #{event}"
    AGGREGATOR << event
  end
end

listener = Listener.new
monitor.register_event(:test)

monitor.subscribe(:test) do |event|
  p "block #{event}"
  AGGREGATOR << event
end
monitor.subscribe(listener)

monitor.publish(:test, foo: "bar")

begin
  monitor.unsubscribe(listener)
rescue => e
  p e
  # => #<NoMethodError: undefined method `receiver' for #<Proc:0x000000010389a2e8 bin/console:29>>
end
```

Since Proc instances do not have a receiver, in case the same bus instance is subscribed to with a block and an event listener object, `#unsubscribe` raises an exception unless the target listener object exists and precedes the block-based subscribers in the `#listeners` hash.